### PR TITLE
Calculate damage using exactextract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
+# Custom
+development
+data/inundation_maps
+tests/tmp
+tests/output
+*aux.xml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *$py.class
-
-# Development folder
-development
-data/inundation_maps
-tests/tmp
 
 # C extensions
 *.so

--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,5 @@ dependencies:
     - pyproj
     - xarray
     - rioxarray
+    - exactextract
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "shapely >= 2.0",
     "tqdm",
     "pyyaml",
+    "exactextract",
 ]
 
 [tool.setuptools.package-data]

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -10,10 +10,10 @@ def test_match_and_load_rasters():
     landuse_file = data_path / "landuse" / "landuse_map.tif"
     hazard_file = data_path / "hazard" / "inundation_map.tif"
 
-    with rasterio.open(landuse_file) as src1, rasterio.open(hazard_file) as src2:
+    with rasterio.open(landuse_file) as src:
         # Read the data and transform from the landuse file
-        landuse_data = src1.read(1)
-        landuse_transform = src1.transform
+        landuse_data = src.read(1)
+        landuse_transform = src.transform
 
         # Extend the landuse data in all directions
         extended_landuse_data = np.pad(
@@ -40,7 +40,7 @@ def test_match_and_load_rasters():
             width=extended_landuse_data.shape[1],
             count=1,
             dtype=extended_landuse_data.dtype,
-            crs=src1.crs,
+            crs=src.crs,
             transform=new_transform,
         ) as dst:
             dst.write(extended_landuse_data, 1)

--- a/tests/test_vectorscanner.py
+++ b/tests/test_vectorscanner.py
@@ -1,0 +1,61 @@
+from damagescanner.core import VectorScanner, calculate_damage_per_object
+from .setup import data_path, output_folder
+import geopandas as gpd
+import pandas as pd
+import rasterio
+import rioxarray as rxr
+from exactextract import exact_extract
+
+
+def test_calculate_damage_per_object():
+    objects = gpd.read_file(data_path / "landuse" / "landuse.shp")
+    objects = objects[objects['landuse'].isin([
+        'residential',
+        'grass',
+        'industrial',
+        'farmland',
+        'forest',
+        'orchard',
+    ])]
+    objects['landuse'] = objects['landuse'].map({
+        'residential': "111",
+        'grass': "230",
+        'industrial': "150",
+        'farmland': "230",
+        'forest': "360",
+        'orchard': "240",
+    })
+    hazard = rasterio.open(data_path / "hazard" / "inundation_map.tif")
+    curves = pd.read_csv(data_path / "curves" / "curves.csv", dtype={"landuse": str}).set_index('Unnamed: 0')
+    maximum_damage = pd.read_csv(data_path / "curves" / "maxdam.csv", dtype={"landuse": str}).set_index("landuse")
+
+    objects['damage_rasterio'] = calculate_damage_per_object(
+        objects=objects,
+        hazard=hazard,
+        curves=curves,
+        maximum_damage=maximum_damage,
+        column='landuse',
+    )
+    objects.to_file(output_folder / "damaged_objects_rasterio.gpkg", driver="GPKG")
+
+    hazard = rxr.open_rasterio(data_path / "hazard" / "inundation_map.tif")
+    objects['damage_xarray'] = calculate_damage_per_object(
+        objects=objects,
+        hazard=hazard,
+        curves=curves,
+        maximum_damage=maximum_damage,
+        column='landuse',
+    )
+    objects.to_file(output_folder / "damaged_objects_xarray.gpkg", driver="GPKG")
+
+    assert objects['damage_rasterio'].equals(objects['damage_xarray'])
+
+
+def test_exact_extract():
+    exposure_file = gpd.read_file(data_path / "landuse" / "landuse.shp")
+    hazard_file = data_path / "hazard" / "inundation_map.tif"
+
+    average = exact_extract(
+        hazard_file, exposure_file, ["mean"], output="pandas", include_geom=True
+    )
+    average.to_file(output_folder / "inundation_map.gpkg")

--- a/tests/test_vectorscanner.py
+++ b/tests/test_vectorscanner.py
@@ -49,13 +49,3 @@ def test_calculate_damage_per_object():
     objects.to_file(output_folder / "damaged_objects_xarray.gpkg", driver="GPKG")
 
     assert objects['damage_rasterio'].equals(objects['damage_xarray'])
-
-
-def test_exact_extract():
-    exposure_file = gpd.read_file(data_path / "landuse" / "landuse.shp")
-    hazard_file = data_path / "hazard" / "inundation_map.tif"
-
-    average = exact_extract(
-        hazard_file, exposure_file, ["mean"], output="pandas", include_geom=True
-    )
-    average.to_file(output_folder / "inundation_map.gpkg")


### PR DESCRIPTION
A new package called "exact_extract" is a highly efficient package for zonal statistics was recently developed (or at least the Python interface for it). Here, I created a new function that calculates the damage per object using that package.

I want to make it a more "bare-bones" function without all the file handling compared to the VectorScanner. This way, if you want we could connect the VectorScanner function to this one, but perhaps some testing would be needed first to compare speed, exactness etc.